### PR TITLE
Use all categories by default

### DIFF
--- a/src/VAP/AML.Client/AMLCaller.cs
+++ b/src/VAP/AML.Client/AMLCaller.cs
@@ -41,7 +41,7 @@ namespace AML.Client
             Utils.Utils.cleanFolder(@OutputFolder.OutputFolderAML);
         }
 
-        public static async Task<List<bool>> Run(int frameIndex, List<Item> items, Dictionary<string, int> category)
+        public static async Task<List<bool>> Run(int frameIndex, List<Item> items, HashSet<string> category)
         {
             //could implement AML triggering criteria here, e.g., confidence
 
@@ -88,7 +88,7 @@ namespace AML.Client
                                 char[] delimiterChars = { ' ', ',' };
                                 foreach (var key in GetLabel(kvp.Key).Split(delimiterChars))
                                 {
-                                    if (category.ContainsKey(key))
+                                    if (category.Contains(key))
                                     {
                                         amlResult.Add(true);
 

--- a/src/VAP/AML.Client/AMLCaller.cs
+++ b/src/VAP/AML.Client/AMLCaller.cs
@@ -88,7 +88,7 @@ namespace AML.Client
                                 char[] delimiterChars = { ' ', ',' };
                                 foreach (var key in GetLabel(kvp.Key).Split(delimiterChars))
                                 {
-                                    if (category.Contains(key))
+                                    if (category.Count == 0 || category.Contains(key))
                                     {
                                         amlResult.Add(true);
 

--- a/src/VAP/DarknetDetector/CascadedDNNYolo.cs
+++ b/src/VAP/DarknetDetector/CascadedDNNYolo.cs
@@ -37,7 +37,7 @@ namespace DarknetDetector
             Utils.Utils.cleanFolder(@OutputFolder.OutputFolderCcDNN);
         }
 
-        public List<Item> Run(Mat frame, int frameIndex, List<Item> ltDNNItemList, List<Tuple<string, int[]>> lines, Dictionary<string, int> category)
+        public List<Item> Run(Mat frame, int frameIndex, List<Item> ltDNNItemList, List<Tuple<string, int[]>> lines, HashSet<string> category)
         {
             if (ltDNNItemList == null)
             {

--- a/src/VAP/DarknetDetector/FrameDNNYolo.cs
+++ b/src/VAP/DarknetDetector/FrameDNNYolo.cs
@@ -50,9 +50,9 @@ namespace DarknetDetector
             frameYoloTracking.SetTrackingObject(trackingObject);
         }
 
-        public List<YoloTrackingItem> Detect(byte[] imgByte, Dictionary<string, int> cat, int lineID, Brush bboxColor, double min_score_for_linebbox_overlap, int frameIndex = 0)
+        public List<YoloTrackingItem> Detect(byte[] imgByte, HashSet<string> category, int lineID, Brush bboxColor, double min_score_for_linebbox_overlap, int frameIndex = 0)
         {
-            IEnumerable<YoloTrackingItem> yoloItems = frameYoloTracking.Analyse(imgByte, cat, bboxColor);
+            IEnumerable<YoloTrackingItem> yoloItems = frameYoloTracking.Analyse(imgByte, category, bboxColor);
             
             return OverlapVal(imgByte, yoloItems, lineID, bboxColor, min_score_for_linebbox_overlap);
         }
@@ -98,11 +98,11 @@ namespace DarknetDetector
             }
         }
 
-        public List<Item> Run(byte[] imgByte, int frameIndex, List<Tuple<string, int[]>> lines, Dictionary<string, int> cat, Brush bboxColor)
+        public List<Item> Run(byte[] imgByte, int frameIndex, List<Tuple<string, int[]>> lines, HashSet<string> category, Brush bboxColor)
         {
             List<Item> frameDNNItem = new List<Item>();
 
-            IEnumerable<YoloTrackingItem> yoloItems = frameYoloTracking.Analyse(imgByte, cat, bboxColor);
+            IEnumerable<YoloTrackingItem> yoloItems = frameYoloTracking.Analyse(imgByte, category, bboxColor);
 
             for (int lineID = 0; lineID < lines.Count; lineID++)
             {

--- a/src/VAP/DarknetDetector/LineTriggeredDNNYolo.cs
+++ b/src/VAP/DarknetDetector/LineTriggeredDNNYolo.cs
@@ -41,7 +41,7 @@ namespace DarknetDetector
             Utils.Utils.cleanFolder(@OutputFolder.OutputFolderLtDNN);
         }
 
-        public List<Item> Run(Mat frame, int frameIndex, Dictionary<string, bool> occupancy, List<Tuple<string, int[]>> lines, Dictionary<string, int> category)
+        public List<Item> Run(Mat frame, int frameIndex, Dictionary<string, bool> occupancy, List<Tuple<string, int[]>> lines, HashSet<string> category)
         {
             // buffer frame
             frameBufferLtDNNYolo.Buffer(frame);

--- a/src/VAP/TFDetector/FrameDNNTF.cs
+++ b/src/VAP/TFDetector/FrameDNNTF.cs
@@ -20,7 +20,7 @@ namespace TFDetector
     {
         private static int _imageWidth, _imageHeight, _index;
         private static List<Tuple<string, int[]>> _lines;
-        private static Dictionary<string, int> _category;
+        private static HashSet<string> _category;
 
         TFWrapper tfWrapper = new TFWrapper();
         byte[] imageByteArray;
@@ -31,7 +31,7 @@ namespace TFDetector
             _lines = lines;
         }
 
-        public List<Item> Run(Mat frameTF, int frameIndex, Dictionary<string, int> category, Brush bboxColor, double min_score_for_linebbox_overlap)
+        public List<Item> Run(Mat frameTF, int frameIndex, HashSet<string> category, Brush bboxColor, double min_score_for_linebbox_overlap)
         {
             _imageWidth = frameTF.Width;
             _imageHeight = frameTF.Height;
@@ -99,7 +99,7 @@ namespace TFDetector
 
                     int value = Convert.ToInt32(classes[i, j]);
                     CatalogItem catalogItem = TFWrapper._catalog.FirstOrDefault(item => item.Id == value);
-                    if (!_category.ContainsKey(catalogItem.DisplayName)) continue;
+                    if (!_category.Contains(catalogItem.DisplayName)) continue;
 
                     for (int k = 0; k < z; k++)
                     {

--- a/src/VAP/TFDetector/FrameDNNTF.cs
+++ b/src/VAP/TFDetector/FrameDNNTF.cs
@@ -99,7 +99,7 @@ namespace TFDetector
 
                     int value = Convert.ToInt32(classes[i, j]);
                     CatalogItem catalogItem = TFWrapper._catalog.FirstOrDefault(item => item.Id == value);
-                    if (!_category.Contains(catalogItem.DisplayName)) continue;
+                    if (_category.Count > 0 && !_category.Contains(catalogItem.DisplayName)) continue;
 
                     for (int k = 0; k < z; k++)
                     {

--- a/src/VAP/TFDetector/LineTriggeredDNNTF.cs
+++ b/src/VAP/TFDetector/LineTriggeredDNNTF.cs
@@ -28,7 +28,7 @@ namespace TFDetector
             Utils.Utils.cleanFolder(@OutputFolder.OutputFolderLtDNN);
         }
 
-        public List<Item> Run(Mat frame, int frameIndex, Dictionary<string, bool> occupancy, List<Tuple<string, int[]>> lines, Dictionary<string, int> category)
+        public List<Item> Run(Mat frame, int frameIndex, Dictionary<string, bool> occupancy, List<Tuple<string, int[]>> lines, HashSet<string> category)
         {
             // buffer frame
             frameBufferLtDNNTF.Buffer(frame);

--- a/src/VAP/VideoPipelineCore/Program.cs
+++ b/src/VAP/VideoPipelineCore/Program.cs
@@ -22,7 +22,7 @@ namespace VideoPipelineCore
         static void Main(string[] args)
         {
             //parse arguments
-            if (args.Length < 5)
+            if (args.Length < 4)
             {
                 Console.WriteLine(args.Length);
                 Console.WriteLine("Usage: <exe> <video url> <cfg file> <samplingFactor> <resolutionFactor> <category1> <category2> ...");

--- a/src/VAP/VideoPipelineCore/Program.cs
+++ b/src/VAP/VideoPipelineCore/Program.cs
@@ -44,10 +44,10 @@ namespace VideoPipelineCore
             int SAMPLING_FACTOR = int.Parse(args[2]);
             double RESOLUTION_FACTOR = double.Parse(args[3]);
 
-            Dictionary<string, int> category = new Dictionary<string, int>();
+            HashSet<string> category = new HashSet<string>();
             for (int i = 4; i < args.Length; i++)
             {
-                category.Add(args[i], 0);
+                category.Add(args[i]);
             }
 
             //initialize pipeline settings

--- a/src/VAP/VideoPipelineCore/Properties/launchSettings.json
+++ b/src/VAP/VideoPipelineCore/Properties/launchSettings.json
@@ -1,8 +1,12 @@
 {
   "profiles": {
-    "VideoPipelineCore": {
+    "Sample (cars)": {
       "commandName": "Project",
       "commandLineArgs": "sample.mp4 sample.txt 1 1 car"
+    },
+    "Sample (all categories)": {
+      "commandName": "Project",
+      "commandLineArgs": "sample.mp4 sample.txt 1 1"
     }
   }
 }

--- a/src/VAP/YoloWrapper/YoloTracking.cs
+++ b/src/VAP/YoloWrapper/YoloTracking.cs
@@ -68,7 +68,7 @@ namespace Wrapper.Yolo
         private List<YoloItem> FindAllMatch(IEnumerable<YoloItem> items, int maxDistance, HashSet<string> category)
         {
             List<YoloItem> yItems = new List<YoloItem>();
-            var distanceItems = items.Select(o => new { Category = o.Type, Distance = this.Distance(o.Center(), this._trackingObject), Item = o }).Where(o => category.Contains(o.Category) && o.Distance <= maxDistance).OrderBy(o => o.Distance);
+            var distanceItems = items.Select(o => new { Category = o.Type, Distance = this.Distance(o.Center(), this._trackingObject), Item = o }).Where(o => (category.Count == 0 || category.Contains(o.Category)) && o.Distance <= maxDistance).OrderBy(o => o.Distance);
             foreach (var item in distanceItems)
             {
                 YoloItem yItem = item.Item;

--- a/src/VAP/YoloWrapper/YoloTracking.cs
+++ b/src/VAP/YoloWrapper/YoloTracking.cs
@@ -30,7 +30,7 @@ namespace Wrapper.Yolo
             this._trackingObject = trackingObject;
         }
 
-        public List<YoloTrackingItem> Analyse(byte[] imageData, Dictionary<string, int> cat, Brush bboxColor)
+        public List<YoloTrackingItem> Analyse(byte[] imageData, HashSet<string> category, Brush bboxColor)
         {
             var items = this._yoloWrapper.Track(imageData);
             if (items == null || items.Count() == 0)
@@ -38,7 +38,7 @@ namespace Wrapper.Yolo
                 return null;
             }
 
-            var probableObject = this.FindAllMatch(items, this._maxDistance, cat);
+            var probableObject = this.FindAllMatch(items, this._maxDistance, category);
             if (probableObject.Count() == 0)
             {
                 return null;
@@ -65,10 +65,10 @@ namespace Wrapper.Yolo
         }
 
         //find all match based on distance
-        private List<YoloItem> FindAllMatch(IEnumerable<YoloItem> items, int maxDistance, Dictionary<string, int> cat)
+        private List<YoloItem> FindAllMatch(IEnumerable<YoloItem> items, int maxDistance, HashSet<string> category)
         {
             List<YoloItem> yItems = new List<YoloItem>();
-            var distanceItems = items.Select(o => new { Cat = o.Type, Distance = this.Distance(o.Center(), this._trackingObject), Item = o }).Where(o => (cat.ContainsKey(o.Cat) && o.Distance <= maxDistance)).OrderBy(o => o.Distance);
+            var distanceItems = items.Select(o => new { Category = o.Type, Distance = this.Distance(o.Center(), this._trackingObject), Item = o }).Where(o => category.Contains(o.Category) && o.Distance <= maxDistance).OrderBy(o => o.Distance);
             foreach (var item in distanceItems)
             {
                 YoloItem yItem = item.Item;


### PR DESCRIPTION
* Use a `HashSet<string>` for categories instead of `Dictionary<string, int>` with a meaningless value
* When no categories are specified on the command line, default to using all categories